### PR TITLE
feat: make image bump logic idempotent

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,19 +51,32 @@ runs:
         git config user.name "${{ github.workflow }}"
         # This email identifies the commit as GitHub Actions - see https://github.com/orgs/community/discussions/26560
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
         if [[ ${{inputs.branch}} != 'main' ]]; then
           git checkout -B ${{ inputs.branch }}
         fi
+        
         git add ${{ inputs.file_path }}
-        git diff-index --cached --quiet HEAD ||
-          git commit -m "Bump chainguard image for ${{ inputs.image_name }}" -m "[skip ci]" &&
-          git push origin ${{ inputs.branch }}
+        
+        if ! git diff-index --cached --quiet HEAD; then
+          git commit -m "Bump chainguard image for ${{ inputs.image_name }}" -m "[skip ci]"
+          git push origin ${{ inputs.branch }} --force
+          echo "HAS_CHANGES=true" >> $GITHUB_ENV
+        else
+          echo "No changes detected. Skipping push and PR."
+          echo "HAS_CHANGES=false" >> $GITHUB_ENV
+        fi
     - name: Create PR for branch ${{ inputs.branch }}
-      if: ${{ inputs.branch != 'main' }}
+      if: ${{ inputs.branch != 'main' && env.HAS_CHANGES == 'true' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         set -ex
-        gh pr create --title "Bump chainguard image for ${{ inputs.image_name }}" --fill --base main --head ${{ inputs.branch }}
-
+        PR_EXISTS=$(gh pr list --head ${{ inputs.branch }} --json number --jq '.[0].number')
+          
+        if [ -z "$PR_EXISTS" ]; then
+          gh pr create --title "Bump chainguard image for ${{ inputs.image_name }}" --fill --base main --head ${{ inputs.branch }}
+        else
+          echo "PR already exists for ${{ inputs.branch }}. GitHub will update it automatically."
+        fi


### PR DESCRIPTION
This PR makes the image digest update process more robust by addressing the following 3 issues:

**Empty Pull Requests** By implementing a git diff-index check and the HAS_CHANGES variable, the action now only attempts to commit and push if a new image digest was actually found. This prevents the workflow from failing or creating unnecessary "empty" noise when images are already up-to-date.

**Rejected Pushes** We now use git push --force to update the automated branches. Since these are short-lived bot branches, forcing the push is the most efficient way to resolve "non-fast-forward" errors (rejected pushes) that occur when the remote branch history has diverged from the runner's local state.

**Redundant PR Creation** Previously, gh pr create would cause the workflow to crash if a Pull Request from a previous run was still open. A check was added using if [ -z "$PR_EXISTS" ] to verify the PR status first. If a PR already exists, the action gracefully skips the creation step and allows the force-push to update the existing PR instead.